### PR TITLE
Update readme to reflect accurate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,25 +82,25 @@ Suppose you had the following `simple_iptables` configuration:
 
     # Allow any established connections to continue, even
     # if they would be in violation of other rules.
-    iptables_rule "system" do
+    simple_iptables_rule "system" do
       rule "-m conntrack --ctstate ESTABLISHED,RELATED"
       jump "ACCEPT"
     end
 
     # Allow SSH
-    iptables_rule "system" do
+    simple_iptables_rule "system" do
       rule "--proto tcp --dport 22"
       jump "ACCEPT"
     end
 
     # Allow HTTP
-    iptables_rule "system" do
+    simple_iptables_rule "system" do
       rule "--proto tcp --dport 80"
       jump "ACCEPT"
     end
 
     # And HTTPS
-    iptables_rule "system" do
+    simple_iptables_rule "system" do
       rule "--proto tcp --dport 443"
       jump "ACCEPT"
     end


### PR DESCRIPTION
Change the example rules to use simple_iptables_rule instead of just iptables_rule.  iptables_rule seems to have the iptables_rule however is not compatible.  Using simple_iptables_rule in my setup has proven to work.
