### PR TITLE
Fixed Chef 11 attribute without precedence warning

### DIFF
--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -1,5 +1,5 @@
 action :set do
   Chef::Log.debug("setting policy for #{new_resource.chain} to #{new_resource.policy}")
-  node["simple_iptables"]["policy"][new_resource.chain] = new_resource.policy
+  node.set["simple_iptables"]["policy"][new_resource.chain] = new_resource.policy
   new_resource.updated_by_last_action(true)
 end


### PR DESCRIPTION
Using Chef `10.16.2` the following warning occurs:

```
[2012-11-03T12:04:48-04:00] WARN: Setting attributes without specifying a precedence is deprecated and will be
removed in Chef 11.0. To set attributes at normal precedence, change code like:
`node["key"] = "value"` # Not this
to:
`node.set["key"] = "value"` # This

Called from:
  /var/cache/chef/cookbooks/simple_iptables/providers/policy.rb:3:in `block in class_from_file'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.16.2/lib/chef/provider.rb:207:in `instance_eval'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.16.2/lib/chef/provider.rb:207:in `block in action'
```

In order to suppress the warning, I changed attribute assignments in the `policy` provider to include `node.set` explicitly.
