### PR TITLE
use default node attribute precedence

### DIFF
--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -11,15 +11,15 @@ action :append do
   test_rules(new_resource, rules)
 
   if not node["simple_iptables"]["chains"].include?(new_resource.chain)
-    node["simple_iptables"]["chains"] << new_resource.chain
-    node["simple_iptables"]["rules"] << "-A #{new_resource.direction} --jump #{new_resource.chain}"
+    node.default["simple_iptables"]["chains"] << new_resource.chain
+    node.default["simple_iptables"]["rules"] << "-A #{new_resource.direction} --jump #{new_resource.chain}"
   end
 
   # Then apply the rules to the node
   rules.each do |rule|
     new_rule = rule_string(new_resource, rule)
     if not node["simple_iptables"]["rules"].include?(new_rule)
-      node["simple_iptables"]["rules"] << new_rule
+      node.default["simple_iptables"]["rules"] << new_rule
       new_resource.updated_by_last_action(true)
       Chef::Log.debug("added rule '#{new_rule}'")
     else


### PR DESCRIPTION
Hey @dcrosta It seems the [Chef 11 Attributes changes](http://www.opscode.com/blog/2013/02/05/chef-11-in-depth-attributes-changes/) trigger Chef::Exceptions::ImmutableAttributeModification when the rule provider tries to set attributes without providing the precedence to use. If I simply use the default precedence this seems to work fine in Chef 11. 

Does this look cogent to you? 
