### PR TITLE
Fix bug in line detection of iptables-restore --test.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,7 +75,7 @@ STDOUT:
 STDERR:
 #{cmd.stderr}
 eos
-      match = cmd.stderr.match /Error occurred at line: (\d+)/
+      match = cmd.stderr.match /line:?\s*(\d+)/
       if match
         line_no = match[1].to_i
         msg << "Line #{line_no}: #{IO.readlines(iptable_rules)[line_no-1]}"


### PR DESCRIPTION
When having errors in iptables rules, I get the following error:

```
[2014-07-14T21:46:59+02:00] ERROR: ruby_block[test-iptables] (simple_iptables::default line 65) had an error: RuntimeError: iptables-restore exited with code 1 while testing new rules
STDOUT:

STDERR:
iptables-restore: line 31 failed
```

It doesn't show what rule failed, and the file is deleted afterwards. I am running on Debian 7.

This commit solves my problem.

Best regards,
Kim
