### PR TITLE
load rules on reboot for rhel >=7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -125,6 +125,16 @@ eos
       content "#!/bin/bash\nip#{v}tables-restore < #{iptable_rules}\n"
       action :create
     end
+  when 'rhel'
+    if node['platform_version'].to_i >= 7
+      package "iptables-services"
+      service "iptables" do
+        action [ :enable, :start ]
+      end
+      service "ip6tables" do
+        action [ :enable, :start ]
+      end
+    end
   end
 end
 


### PR DESCRIPTION
On platform_family rhel >= 7 install iptables-services package and enable/start the services. That ways rules are loaded on boot.
