### PR TITLE
Update Test Kitchen tests for Serverspec 2.x

### DIFF
--- a/test/shared/spec_helper.rb
+++ b/test/shared/spec_helper.rb
@@ -1,12 +1,6 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+
+set :backend, :exec
 
 # Require support files
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |file| require_relative(file) }
-
-RSpec.configure do |config|
-  config.before(:all) do
-    config.os = backend(Serverspec::Commands::Base).check_os
-  end
-end


### PR DESCRIPTION
Test Kitchen tests error out because spec_helper.rb was generated with an older version of Serverspec than Test Kitchen currently loads.
