### PR TITLE
Default comment to name attribute

### DIFF
--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -7,7 +7,7 @@ attribute :jump, :kind_of => [String, FalseClass], :default => "ACCEPT"
 attribute :direction, :equal_to => ["INPUT", "FORWARD", "OUTPUT", "PREROUTING", "POSTROUTING", :none], :default => "INPUT"
 attribute :chain_condition, :kind_of => [String]
 attribute :weight, :kind_of => Integer, :default => 50
-attribute :comment, :kind_of => String
+attribute :comment, :kind_of => String, :default => lazy { |r| r.name }
 attribute :ip_version, :equal_to => [:ipv4, :ipv6, :both], :default => :ipv4
 
 def initialize(*args)


### PR DESCRIPTION
By default, set the comment for a rule to the resource name. This enables simple rule creation with nice comments. Of course, if a user wants to they can still set an arbitrary resource name and specify a comment separately.

Instead of:
```ruby
simple_iptables_rule 'some arbitrary thing' do
  comment 'accept all on loopback interface'
  chain 'INPUT'
  rule '--in-interface lo'
  jump 'ACCEPT'
  weight 1
end
```

We can now do this:
```ruby
simple_iptables_rule 'accept all on loopback interface' do
  chain 'INPUT'
  rule '--in-interface lo'
  jump 'ACCEPT'
  weight 1
end
```