### PR TITLE
Add matchers for ChefSpec

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,17 @@
+if defined?(ChefSpec)
+  ChefSpec.define_matcher :simple_iptables_policy
+  ChefSpec.define_matcher :simple_iptables_rule
+
+  def set_simple_iptables_policy(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:simple_iptables_policy,
+                                            :set,
+                                            resource_name)
+  end
+
+  def append_simple_iptables_rule(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:simple_iptables_rule,
+                                            :append,
+                                            resource_name)
+  end
+end
+


### PR DESCRIPTION
Add matchers so consumers can easily test in wrapper cookbooks. This is just a good standard practice for community cookbooks even if this cookbook doesn't specifically use RSpec/ChefSpec.