### PR TITLE
support aws

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -126,7 +126,7 @@ eos
       action :create
     end
   when 'rhel'
-    if node['platform_version'].to_i >= 7
+    if node['platform'] != 'amazon' && node['platform_version'].to_i >= 7
       package "iptables-services"
       service "iptables" do
         action [ :enable, :start ]


### PR DESCRIPTION
AWS reports as a rhel host but does not use the same numbering than
centos/rhel