### PR TITLE
foodcritic fix and simple_iptables_rule "rule" defaults to ""

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,9 +387,10 @@ Which results in the following iptables configuration:
 
 Changes
 =======
-* 0.7.2 (June 10, 2015)
-    * simple_iptables_rule attribute "rule" defaults to ""
-    * fixed foodcritic errors saying provider needed to always call new_resource.updated_by_last_action
+* 0.7.2 (June 12, 2015)
+    * simple_iptables_rule attribute "rule" defaults to "" (#71 - rtkcstegel)
+    * fixed foodcritic errors saying provider needed to always call new_resource.updated_by_last_action (#71 - rtkcstegel)
+    * support aws AMI (#69 - chantra)
 * 0.7.1 (Feburary 5, 2015)
     * Allow setting comment for rule (#57 - TheMeier)
     * Load rules on reboot on RHEL 7 and later (#58 - TheMeier)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ You may use the weight parameter for control the order of the rules in chains. F
 
     simple_iptables_rule "reject" do
       direction "INPUT"
-      rule ""
       jump "REJECT --reject-with icmp-host-prohibited"
       weight 90
     end
@@ -143,7 +142,7 @@ specified to make the jump conditional. For example:
 The rules specified under the `rule` attribute will only be evaluate for packets for which
 the rule in `chain_condition` holds.
 
-Sometimes we might want to define a chain where we only want to jump from another chain we define. 
+Sometimes we might want to define a chain where we only want to jump from another chain we define.
 By default, an automatic jump will be made to chains defined using the `simple_iptables_rule` resource
 from the chain specified using the `direction` attribute of the resource. To prevent jumping to the
 chain from the direction chains, we can set the direction attribute to the symbol `:none`.
@@ -263,11 +262,11 @@ Suppose you had the following `simple_iptables` configuration:
     simple_iptables_policy "INPUT" do
       policy "DROP"
     end
-    
+
     # The following rules define a "system" chain; chains
     # are used as a convenient way of grouping rules together,
     # for logical organization.
-    
+
     # Allow all traffic on the loopback device
     simple_iptables_rule "system" do
       rule [ # Allow all traffic on the loopback device
@@ -280,14 +279,14 @@ Suppose you had the following `simple_iptables` configuration:
            ]
       jump "ACCEPT"
     end
-    
+
     # Allow HTTP, HTTPS
     simple_iptables_rule "http" do
       rule [ "--proto tcp --dport 80",
              "--proto tcp --dport 443" ]
       jump "ACCEPT"
     end
-    
+
     # Tomcat redirects
     simple_iptables_rule "tomcat" do
       table "nat"
@@ -346,48 +345,50 @@ Which results in the following iptables configuration:
 
     # iptables -L
     Chain INPUT (policy DROP)
-    target     prot opt source               destination         
-    system     all  --  anywhere             anywhere            
-    http       all  --  anywhere             anywhere            
-    
+    target     prot opt source               destination
+    system     all  --  anywhere             anywhere
+    http       all  --  anywhere             anywhere
+
     Chain FORWARD (policy ACCEPT)
-    target     prot opt source               destination         
-    
+    target     prot opt source               destination
+
     Chain OUTPUT (policy ACCEPT)
-    target     prot opt source               destination         
-    
+    target     prot opt source               destination
+
     Chain http (1 references)
-    target     prot opt source               destination         
+    target     prot opt source               destination
     ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:http
     ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:https
-    
+
     Chain system (1 references)
-    target     prot opt source               destination         
-    ACCEPT     all  --  anywhere             anywhere            
+    target     prot opt source               destination
+    ACCEPT     all  --  anywhere             anywhere
     ACCEPT     all  --  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:ssh
 
     #iptables -L -t nat
     Chain PREROUTING (policy ACCEPT)
-    target     prot opt source               destination         
-    tomcat     all  --  anywhere             anywhere            
-    
+    target     prot opt source               destination
+    tomcat     all  --  anywhere             anywhere
+
     Chain INPUT (policy ACCEPT)
-    target     prot opt source               destination         
-    
+    target     prot opt source               destination
+
     Chain OUTPUT (policy ACCEPT)
-    target     prot opt source               destination         
-    
+    target     prot opt source               destination
+
     Chain POSTROUTING (policy ACCEPT)
-    target     prot opt source               destination         
-    
+    target     prot opt source               destination
+
     Chain tomcat (1 references)
-    target     prot opt source               destination         
+    target     prot opt source               destination
     REDIRECT   tcp  --  anywhere             anywhere             tcp dpt:http redir ports 8080
     REDIRECT   tcp  --  anywhere             anywhere             tcp dpt:https redir ports 8443
 
 Changes
 =======
+* 0.7.2 (June 10, 2015)
+    * simple_iptables_rule attribute "rule" defaults to ""
 * 0.7.1 (Feburary 5, 2015)
     * Allow setting comment for rule (#57 - TheMeier)
     * Load rules on reboot on RHEL 7 and later (#58 - TheMeier)

--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Changes
 =======
 * 0.7.2 (June 10, 2015)
     * simple_iptables_rule attribute "rule" defaults to ""
+    * fixed foodcritic errors saying provider needed to always call new_resource.updated_by_last_action
 * 0.7.1 (Feburary 5, 2015)
     * Allow setting comment for rule (#57 - TheMeier)
     * Load rules on reboot on RHEL 7 and later (#58 - TheMeier)

--- a/metadata.json
+++ b/metadata.json
@@ -29,5 +29,5 @@
   },
   "recipes": {
   },
-  "version": "0.7.1"
+  "version": "0.7.2"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "dev@arcticwolf.com"
 license          "BSD"
 description      "Simple LWRP and recipe for managing iptables rules"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.7.1"
+version          "0.7.2"
 name             "simple_iptables"
 
 supports "debian", ">= 6.0"

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -1,14 +1,16 @@
 action :set do
+  updated = false
   if [:ipv4, :both].include?(new_resource.ip_version)
-    handle_policy(new_resource, "ipv4")
+    updated ||= handle_policy(new_resource, "ipv4")
   end
   if [:ipv6, :both].include?(new_resource.ip_version)
-    handle_policy(new_resource, "ipv6")
+    updated ||= handle_policy(new_resource, "ipv6")
   end
+  new_resource.updated_by_last_action(updated)
 end
 
 def handle_policy(new_resource, ip_version)
   Chef::Log.debug("[#{ip_version}] setting policy for #{new_resource.chain} to #{new_resource.policy}")
   node.set["simple_iptables"][ip_version]["policy"][new_resource.table][new_resource.chain] = new_resource.policy
-  new_resource.updated_by_last_action(true)
+  return true
 end

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -14,8 +14,10 @@ end
 def handle_rule(new_resource, ip_version)
   if new_resource.rule.kind_of?(String)
     rules = [new_resource.rule]
-  else
+  elsif new_resource.rule.kind_of?(Array)
     rules = new_resource.rule
+  else
+    rules = ['']
   end
   if not node["simple_iptables"][ip_version]["chains"][new_resource.table].include?(new_resource.chain)
     node.set["simple_iptables"][ip_version]["chains"][new_resource.table] = node["simple_iptables"][ip_version]["chains"][new_resource.table].dup << new_resource.chain unless ["PREROUTING", "INPUT", "FORWARD", "OUTPUT", "POSTROUTING"].include?(new_resource.chain)

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -3,12 +3,14 @@ include Chef::Mixin::ShellOut
 
 
 action :append do
+  updated = false
   if [:ipv4, :both].include?(new_resource.ip_version)
-    handle_rule(new_resource, "ipv4")
+    updated ||= handle_rule(new_resource, "ipv4")
   end
   if [:ipv6, :both].include?(new_resource.ip_version)
-    handle_rule(new_resource, "ipv6")
+    updated ||= handle_rule(new_resource, "ipv6")
   end
+  new_resource.updated_by_last_action(updated)
 end
 
 def handle_rule(new_resource, ip_version)
@@ -27,6 +29,7 @@ def handle_rule(new_resource, ip_version)
   end
 
   # Then apply the rules to the node
+  updated = false
   rules.each do |rule|
     new_rule_string = rule_string(new_resource, rule, false)
     new_rule = {:rule => new_rule_string, :weight => new_resource.weight}
@@ -35,12 +38,13 @@ def handle_rule(new_resource, ip_version)
     unless table_rules.include?(new_rule)
       table_rules << new_rule
       table_rules.sort! {|a,b| a[:weight] <=> b[:weight]}
-      new_resource.updated_by_last_action(true)
+      updated = true
       Chef::Log.debug("[#{ip_version}] added rule '#{new_rule_string}'")
     else
       Chef::Log.debug("[#{ip_version}] ignoring duplicate simple_iptables_rule '#{new_rule_string}'")
     end
   end
+  return updated
 end
 
 def rule_string(new_resource, rule, include_table)

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -2,7 +2,7 @@ actions :append
 
 attribute :chain, :name_attribute => true, :kind_of => String
 attribute :table, :equal_to => ["filter", "nat", "mangle", "raw"], :default => "filter"
-attribute :rule, :kind_of => [String, Array], :required => true
+attribute :rule, :kind_of => [String, Array]
 attribute :jump, :kind_of => [String, FalseClass], :default => "ACCEPT"
 attribute :direction, :equal_to => ["INPUT", "FORWARD", "OUTPUT", "PREROUTING", "POSTROUTING", :none], :default => "INPUT"
 attribute :chain_condition, :kind_of => [String]


### PR DESCRIPTION
The "rule" attribute for simple_iptables_rule LWRP now defaults to "".  Sometimes a simple_iptables_rule is needed to be created that has no "rule" section such as: 

```
simple_iptables_rule 'log-input' do
  direction 'INPUT'
  jump 'LOG'
end
```
A foodcritic fix was also addressed, which is explained in the commit.