### PR TITLE
Avoid Lazy Defaults in LWRP Definitions

### DIFF
--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -50,7 +50,7 @@ end
 def rule_string(new_resource, rule, include_table)
   jump = new_resource.jump ? "--jump #{new_resource.jump} " : ""
   table = include_table ? "--table #{new_resource.table} " : ""
-  comment = new_resource.comment ? %Q{ -m comment --comment "#{new_resource.comment}" } : ""
+  comment = %Q{ -m comment --comment "#{new_resource.comment || new_resource.name}" }
   rule = "#{table}-A #{new_resource.chain} #{jump}#{rule}#{comment}"
   rule
 end

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -7,7 +7,7 @@ attribute :jump, :kind_of => [String, FalseClass], :default => "ACCEPT"
 attribute :direction, :equal_to => ["INPUT", "FORWARD", "OUTPUT", "PREROUTING", "POSTROUTING", :none], :default => "INPUT"
 attribute :chain_condition, :kind_of => [String]
 attribute :weight, :kind_of => Integer, :default => 50
-attribute :comment, :kind_of => String, :default => lazy { |r| r.name }
+attribute :comment, :kind_of => String
 attribute :ip_version, :equal_to => [:ipv4, :ipv6, :both], :default => :ipv4
 
 def initialize(*args)


### PR DESCRIPTION
This was causing problems with older Chef versions. Instead, implement the same
semantics manually.

Fixes #72