### PR TITLE
Fix ipv6 support when using ip-version :both

### DIFF
--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -1,10 +1,10 @@
 action :set do
   updated = false
   if [:ipv4, :both].include?(new_resource.ip_version)
-    updated ||= handle_policy(new_resource, "ipv4")
+    updated |= handle_policy(new_resource, "ipv4")
   end
   if [:ipv6, :both].include?(new_resource.ip_version)
-    updated ||= handle_policy(new_resource, "ipv6")
+    updated |= handle_policy(new_resource, "ipv6")
   end
   new_resource.updated_by_last_action(updated)
 end

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -5,10 +5,10 @@ include Chef::Mixin::ShellOut
 action :append do
   updated = false
   if [:ipv4, :both].include?(new_resource.ip_version)
-    updated ||= handle_rule(new_resource, "ipv4")
+    updated |= handle_rule(new_resource, "ipv4")
   end
   if [:ipv6, :both].include?(new_resource.ip_version)
-    updated ||= handle_rule(new_resource, "ipv6")
+    updated |= handle_rule(new_resource, "ipv6")
   end
   new_resource.updated_by_last_action(updated)
 end


### PR DESCRIPTION
a ||= b is equivalent to a = a || b
in ff467b78163d759e3b793ee812c2e1ef9b653744 support for ipv6 support got
broken because updated was true after evaluating the ipv4 block.
This caused handle_{policy,rule} to never be evaluated for ipv6.

Fixes #75 

Tested with kitchen converge ipv6-list-of-tables-centos-65