### PR TITLE
Fix the usage of deprecated feature

### DIFF
--- a/resources/policy.rb
+++ b/resources/policy.rb
@@ -1,6 +1,6 @@
 actions :set
 
-attribute :chain, :name_attribute => true, :equal_to => ["INPUT", "FORWARD", "OUTPUT", "PREROUTING", "POSTROUTING"], :default => "INPUT"
+attribute :chain, :name_attribute => true, :equal_to => ["INPUT", "FORWARD", "OUTPUT", "PREROUTING", "POSTROUTING"]
 attribute :table, :equal_to => ["filter", "nat", "mangle", "raw"], :default => "filter"
 attribute :policy, :equal_to => ["ACCEPT", "DROP"], :required => true
 attribute :ip_version, :equal_to => [:ipv4, :ipv6, :both], :default => :ipv4


### PR DESCRIPTION
Should be fine to just use name_attribute here.

```
Deprecated features used!

  Cannot specify both default and name_property together on property chain of resource simple_iptables_policy. Only one (name_property) will be obeyed. In Chef 13, this will become an error. at 1 location:
    - /var/chef/cache/cookbooks/simple_iptables/resources/policy.rb:3:in `class_from_file'
```