### PR TITLE
[~] fix deprecated node.set in chef 14

### DIFF
--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -11,6 +11,6 @@ end
 
 def handle_policy(new_resource, ip_version)
   Chef::Log.debug("[#{ip_version}] setting policy for #{new_resource.chain} to #{new_resource.policy}")
-  node.set["simple_iptables"][ip_version]["policy"][new_resource.table][new_resource.chain] = new_resource.policy
+  node.normal["simple_iptables"][ip_version]["policy"][new_resource.table][new_resource.chain] = new_resource.policy
   return true
 end

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -26,9 +26,9 @@ def handle_rule(new_resource, ip_version)
     rules = ['']
   end
   if not node["simple_iptables"][ip_version]["chains"][new_resource.table].include?(new_resource.chain)
-    node.set["simple_iptables"][ip_version]["chains"][new_resource.table] = node["simple_iptables"][ip_version]["chains"][new_resource.table].dup << new_resource.chain unless ["PREROUTING", "INPUT", "FORWARD", "OUTPUT", "POSTROUTING"].include?(new_resource.chain)
+    node.normal["simple_iptables"][ip_version]["chains"][new_resource.table] = node["simple_iptables"][ip_version]["chains"][new_resource.table].dup << new_resource.chain unless ["PREROUTING", "INPUT", "FORWARD", "OUTPUT", "POSTROUTING"].include?(new_resource.chain)
     unless new_resource.chain == new_resource.direction || new_resource.direction == :none
-      node.set["simple_iptables"][ip_version]["rules"][new_resource.table] << {:rule => "-A #{new_resource.direction} #{new_resource.chain_condition} --jump #{new_resource.chain}", :weight => new_resource.weight}
+      node.normal["simple_iptables"][ip_version]["rules"][new_resource.table] << {:rule => "-A #{new_resource.direction} #{new_resource.chain_condition} --jump #{new_resource.chain}", :weight => new_resource.weight}
     end
   end
 
@@ -37,7 +37,7 @@ def handle_rule(new_resource, ip_version)
   rules.each do |rule|
     new_rule_string = rule_string(new_resource, rule, false)
     new_rule = {:rule => new_rule_string, :weight => new_resource.weight}
-    table_rules = node.set["simple_iptables"][ip_version]["rules"][new_resource.table]
+    table_rules = node.normal["simple_iptables"][ip_version]["rules"][new_resource.table]
 
     unless table_rules.include?(new_rule)
       table_rules << new_rule

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,13 +36,13 @@ ruby_block "run-iptables-resources-early" do
     # Before executing the simple_iptables_* resources, reset the
     # node attributes to their defaults. This gives "action :delete"
     # semantics for free by removing a resource from a recipe.
-    node.set["simple_iptables"]["ipv4"]["chains"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
-    node.set["simple_iptables"]["ipv4"]["rules"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
-    node.set["simple_iptables"]["ipv4"]["policy"] = {"filter" => {}, "nat" => {}, "mangle" => {}, "raw" => {}}
+    node.normal["simple_iptables"]["ipv4"]["chains"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
+    node.normal["simple_iptables"]["ipv4"]["rules"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
+    node.normal["simple_iptables"]["ipv4"]["policy"] = {"filter" => {}, "nat" => {}, "mangle" => {}, "raw" => {}}
 
-    node.set["simple_iptables"]["ipv6"]["chains"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
-    node.set["simple_iptables"]["ipv6"]["rules"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
-    node.set["simple_iptables"]["ipv6"]["policy"] = {"filter" => {}, "nat" => {}, "mangle" => {}, "raw" => {}}
+    node.normal["simple_iptables"]["ipv6"]["chains"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
+    node.normal["simple_iptables"]["ipv6"]["rules"] = {"filter" => [], "nat" => [], "mangle" => [], "raw" => []}
+    node.normal["simple_iptables"]["ipv6"]["policy"] = {"filter" => {}, "nat" => {}, "mangle" => {}, "raw" => {}}
     # Then run all the simple_iptables_* resources
     run_context.resource_collection.each do |resource|
       if resource.kind_of?(Chef::Resource::SimpleIptablesRule)

--- a/test/fixtures/smoke/recipes/ipv6_default.rb
+++ b/test/fixtures/smoke/recipes/ipv6_default.rb
@@ -1,4 +1,4 @@
-node.set["simple_iptables"]["ip_versions"] = ["ipv4", "ipv6"]
+node.normal["simple_iptables"]["ip_versions"] = ["ipv4", "ipv6"]
 
 include_recipe "simple_iptables::default"
 

--- a/test/fixtures/smoke/recipes/ipv6_tables.rb
+++ b/test/fixtures/smoke/recipes/ipv6_tables.rb
@@ -1,6 +1,6 @@
-node.set["simple_iptables"]["ip_versions"] = ["ipv4", "ipv6"]
-node.set["simple_iptables"]["ipv4"]["tables"] = %w(filter mangle)
-node.set["simple_iptables"]["ipv6"]["tables"] = %w(filter mangle)
+node.normal["simple_iptables"]["ip_versions"] = ["ipv4", "ipv6"]
+node.normal["simple_iptables"]["ipv4"]["tables"] = %w(filter mangle)
+node.normal["simple_iptables"]["ipv6"]["tables"] = %w(filter mangle)
 
 include_recipe "simple_iptables::default"
 

--- a/test/fixtures/smoke/recipes/tables.rb
+++ b/test/fixtures/smoke/recipes/tables.rb
@@ -1,4 +1,4 @@
-node.set["simple_iptables"]["ipv4"]["tables"] = %w(filter mangle)
+node.normal["simple_iptables"]["ipv4"]["tables"] = %w(filter mangle)
 
 include_recipe "simple_iptables::default"
 


### PR DESCRIPTION
This should fix the following errors:

Deprecated features used!
node.set is deprecated and will be removed in Chef 14, please use node.default/node.node.normal only if you really need persistence) at 9 locations:
     - /var/chef/cache/cookbooks/simple_iptables/recipes/default.rb:39:in 'block (2 levelse'
     - /var/chef/cache/cookbooks/simple_iptables/recipes/default.rb:40:in 'block (2 levelse'
     - /var/chef/cache/cookbooks/simple_iptables/recipes/default.rb:41:in 'block (2 levelse'
     - /var/chef/cache/cookbooks/simple_iptables/recipes/default.rb:43:in 'block (2 levelse'
     - /var/chef/cache/cookbooks/simple_iptables/recipes/default.rb:44:in 'block (2 levelse'
     - /var/chef/cache/cookbooks/simple_iptables/recipes/default.rb:45:in 'block (2 levelse'
     - /var/chef/cache/cookbooks/simple_iptables/providers/rule.rb:29:in 'handle_rule'
     - /var/chef/cache/cookbooks/simple_iptables/providers/rule.rb:31:in 'handle_rule'
     - /var/chef/cache/cookbooks/simple_iptables/providers/rule.rb:40:in 'block in handle_rule'
